### PR TITLE
Upgrade to v26.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 diagrams.net (formerly draw.io) lets you create a wide range of diagrams, from simple tree and flow diagrams, to highly technical network, rack and electrical diagrams.
 
 
-**Shipped version:** 26.0.16~ynh1
+**Shipped version:** 26.1.0~ynh1
 
 **Demo:** <https://app.diagrams.net/>
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 diagrams.net (formerly draw.io) lets you create a wide range of diagrams, from simple tree and flow diagrams, to highly technical network, rack and electrical diagrams.
 
 
-**Versión actual:** 26.0.16~ynh1
+**Versión actual:** 26.1.0~ynh1
 
 **Demo:** <https://app.diagrams.net/>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 diagrams.net (formerly draw.io) lets you create a wide range of diagrams, from simple tree and flow diagrams, to highly technical network, rack and electrical diagrams.
 
 
-**Paketatutako bertsioa:** 26.0.16~ynh1
+**Paketatutako bertsioa:** 26.1.0~ynh1
 
 **Demoa:** <https://app.diagrams.net/>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Application en ligne qui permet de faire des schémas et du dessin vectoriel
 
 
-**Version incluse :** 26.0.16~ynh1
+**Version incluse :** 26.1.0~ynh1
 
 **Démo :** <https://app.diagrams.net/>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 diagrams.net (formerly draw.io) lets you create a wide range of diagrams, from simple tree and flow diagrams, to highly technical network, rack and electrical diagrams.
 
 
-**Versión proporcionada:** 26.0.16~ynh1
+**Versión proporcionada:** 26.1.0~ynh1
 
 **Demo:** <https://app.diagrams.net/>
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 diagrams.net (formerly draw.io) lets you create a wide range of diagrams, from simple tree and flow diagrams, to highly technical network, rack and electrical diagrams.
 
 
-**Versi terkirim:** 26.0.16~ynh1
+**Versi terkirim:** 26.1.0~ynh1
 
 **Demo:** <https://app.diagrams.net/>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 diagrams.net (formerly draw.io) lets you create a wide range of diagrams, from simple tree and flow diagrams, to highly technical network, rack and electrical diagrams.
 
 
-**Geleverde versie:** 26.0.16~ynh1
+**Geleverde versie:** 26.1.0~ynh1
 
 **Demo:** <https://app.diagrams.net/>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 diagrams.net (formerly draw.io) lets you create a wide range of diagrams, from simple tree and flow diagrams, to highly technical network, rack and electrical diagrams.
 
 
-**Dostarczona wersja:** 26.0.16~ynh1
+**Dostarczona wersja:** 26.1.0~ynh1
 
 **Demo:** <https://app.diagrams.net/>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 diagrams.net (formerly draw.io) lets you create a wide range of diagrams, from simple tree and flow diagrams, to highly technical network, rack and electrical diagrams.
 
 
-**Поставляемая версия:** 26.0.16~ynh1
+**Поставляемая версия:** 26.1.0~ynh1
 
 **Демо-версия:** <https://app.diagrams.net/>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 diagrams.net (formerly draw.io) lets you create a wide range of diagrams, from simple tree and flow diagrams, to highly technical network, rack and electrical diagrams.
 
 
-**分发版本：** 26.0.16~ynh1
+**分发版本：** 26.1.0~ynh1
 
 **演示：** <https://app.diagrams.net/>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Diagrams.net"
 description.en = "Diagram software for making flowcharts, process diagrams, org charts"
 description.fr = "Application qui permet de faire des schémas et du dessin vectoriel"
 
-version = "26.0.16~ynh1"
+version = "26.1.0~ynh1"
 
 maintainers = ["Gofannon"]
 
@@ -43,8 +43,8 @@ ram.runtime = "50M"
     default = "visitors"
 [resources]
         [resources.sources.main]
-        url = "https://github.com/jgraph/drawio/archive/refs/tags/v26.0.16.tar.gz"
-        sha256 = "f66f00221ed4c519234a89570b945aa74802f6ceac0bf9238fcbc664ab72c167"
+        url = "https://github.com/jgraph/drawio/archive/refs/tags/v26.1.0.tar.gz"
+        sha256 = "17bc2514fc8d49da4b16525b4fd0f309cf2a2ea3a6c24a7a0bda7c9522a64789"
         autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]


### PR DESCRIPTION
Upgrade sources
- `main` v26.1.0: https://github.com/jgraph/drawio/releases/tag/26.1.0

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
