### PR TITLE
Upgrade to v26.2.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It shall NOT be edited by hand.
 -->
 
 <h1>
-  <img src="https://raw.githubusercontent.com/YunoHost/apps/master/logos/diagramsnet.png" width="32px" alt="Logo of Diagrams.net">
+  <img src="https://raw.githubusercontent.com/YunoHost/apps/main/logos/diagramsnet.png" width="32px" alt="Logo of Diagrams.net">
   Diagrams.net, packaged for YunoHost
 </h1>
 
@@ -12,7 +12,7 @@ Diagram software for making flowcharts, process diagrams, org charts
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.diagrams.net/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://app.diagrams.net/)
-![Version: 26.2.8~ynh1](https://img.shields.io/badge/Version-26.2.8~ynh1-rgba(0,150,0,1)?style=for-the-badge)
+[![Version: 26.2.15~ynh1](https://img.shields.io/badge/Version-26.2.15~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/diagramsnet/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/diagramsnet"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Diagrams.net"
 description.en = "Diagram software for making flowcharts, process diagrams, org charts"
 description.fr = "Application qui permet de faire des schémas et du dessin vectoriel"
 
-version = "26.2.8~ynh1"
+version = "26.2.15~ynh1"
 
 maintainers = ["Gofannon"]
 
@@ -43,8 +43,8 @@ ram.runtime = "50M"
     default = "visitors"
 [resources]
         [resources.sources.main]
-        url = "https://github.com/jgraph/drawio/archive/refs/tags/v26.2.8.tar.gz"
-        sha256 = "b86fbcad1a3d701622f0e8cbe7955212141c1f3164937a0765c7efe8a2d1ceba"
+        url = "https://github.com/jgraph/drawio/archive/refs/tags/v26.2.15.tar.gz"
+        sha256 = "04bce7d05967c14c2bb14797c350ff23d3a42f71e533b6832b4ba51bd3126cc2"
         autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]


### PR DESCRIPTION
Upgrade sources
- `main` v26.2.15: https://github.com/jgraph/drawio/releases/tag/26.2.15

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
